### PR TITLE
Fix for firefox

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -6,7 +6,7 @@ html(lang="de")
         meta(http-equiv="X-UA-Compatible", content="ie=edge")
         title Deep URL-Shortener
         link(rel="stylesheet", href="/css/style.css")
-        script(src='http://code.jquery.com/jquery-latest.min.js', type='text/javascript')
+        script(src='//code.jquery.com/jquery-latest.min.js', type='text/javascript')
         script(src='/js/script.js', type='text/javascript')
     body
       h1 Robins URL Shortener


### PR DESCRIPTION
Remove protocol in jQuery url to work with firefox privacy protection. Without this JQuery wouldn't load and the page wouldn't work at all. This just loads it with the protocol the page was loaded in.